### PR TITLE
Set Submodel/Kind as per action

### DIFF
--- a/src/AasxPackageLogic/DispEditHelperEntities.cs
+++ b/src/AasxPackageLogic/DispEditHelperEntities.cs
@@ -511,6 +511,14 @@ namespace AasxPackageLogic
                             sm.Id = AdminShellUtil.GenerateIdAccordingTemplate(
                                 (buttonNdx == 2) ? Options.Curr.TemplateIdSubmodelInstance
                                     : Options.Curr.TemplateIdSubmodelTemplate);
+                            if(buttonNdx == 2)
+                            {
+                                sm.Kind = ModellingKind.Instance;
+                            }
+                            else
+                            {
+                                sm.Kind = ModellingKind.Template;
+                            }
                             env.Add(sm);
                             this.AddDiaryEntry(sm, new DiaryEntryStructChange(
                                 StructuralChangeReason.Create));
@@ -1350,8 +1358,12 @@ namespace AasxPackageLogic
                                 submodel.Kind = Aas.ModellingKind.Template;
                             }
                             else
+                            {
                                 submodel.Id = AdminShellUtil.GenerateIdAccordingTemplate(
                                     Options.Curr.TemplateIdSubmodelInstance);
+                                submodel.Kind = ModellingKind.Instance;
+                            }
+                                
 
                             // create ref
                             var smr = new Aas.Reference(Aas.ReferenceTypes.ModelReference, new List<Aas.IKey>() { new Aas.Key(Aas.KeyTypes.Submodel, submodel.Id) });

--- a/src/AasxPackageLogic/DispEditHelperModules.cs
+++ b/src/AasxPackageLogic/DispEditHelperModules.cs
@@ -348,11 +348,15 @@ namespace AasxPackageLogic
                 new HintCheck(
                     () => {
                         int count = 0;
-                        foreach(var aas in env.AssetAdministrationShells)
+                        if(env != null && !env.AssetAdministrationShells.IsNullOrEmpty())
                         {
-                            if(aas.Id == identifiable.Id)
-                                count++;
+                            foreach(var aas in env.AssetAdministrationShells)
+                            {
+                                if(aas.Id == identifiable.Id)
+                                    count++;
+                            }
                         }
+                        
                         return (count >= 2?true:false);
                     },
                     "It is not allowed to have duplicate Ids in AAS of the same file. This will break functionality and we strongly encoure to make the Id unique!",


### PR DESCRIPTION
This PR fixes the issue #222. It sets the Kind of the submodel
as per the action taken.

click on "Add submodel template" within Env "All Submodels"
click on "Add submodel intance" within Env "All Submodels"
click on "Create new Submodel of kind Instance" within a single AAS
already created

Fix:

for 1. Submodel/kind is set to "Template".
for 2. Submodel/kind is set to "Instance".
for 3. Submodel/kind is set to "Instance".