### PR TITLE
Update on AsciiDoc export, direct viewing option

### DIFF
--- a/src/AasxPackageExplorer/options-debug.MIHO.json
+++ b/src/AasxPackageExplorer/options-debug.MIHO.json
@@ -39,7 +39,7 @@
   // "AasxToLoad": "C:\\Users\\homi0002\\Desktop\\SMT_TechData_Work\\IDTA 02003-1-2_SubmodelTemplate_TechnicalData_v1.2__with_Draft_1_3_and_AsciiDoc_v01.aasx",
   // "AasxToLoad": "C:\\Users\\homi0002\\Desktop\\SMT_ProductChangeNotification\\IDTA_02036-1-0_SMT_ProductChangeNotification_Draft_v22.aasx",
   // "AasxToLoad": "C:\\Users\\homi0002\\Desktop\\SMT_ProductChangeNotification\\IDTA_02036-1-0_SMT_ProductChangeNotification_Examples_v08.aasx",
-  "AasxToLoad": "C:\\Users\\homi0002\\Desktop\\SMT_ProductChangeNotification\\SMT_ProductChangeNotification_Draft_v20_spiel.aasx",
+  // "AasxToLoad": "C:\\Users\\homi0002\\Desktop\\SMT_ProductChangeNotification\\SMT_ProductChangeNotification_Draft_v20_spiel.aasx",
   // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\aaspe-testing\\210_Copy_Paste\\Sample_AAS.aasx",
   // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\aaspe-testing\\310_Plugin_DNP\\Sample_AAS.aasx",
   // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\aaspe-testing\\200_Find_Replace\\Sample_SMT.aasx",
@@ -64,7 +64,7 @@
   // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\repo\\aid\\robotic_cell_for_demo_suitcase_new-v3.aasx",
   // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\repo\\IDTA 02006-2-1_Template_Digital Nameplate_V3_Demo_ExportSMT - Kopie.aasx",
   // "AasxToLoad": "C:\\Users\\homi0002\\Desktop\\SMT_ProductChangeNotification\\SMT_ProductChangeNotification_Draft_play_02.aasx",
-  "AasxRepositoryFn": "C:\\HOMI\\Develop\\Aasx\\repo_Festo_demo_case_V3\\Festo-DemoCase-repo-V3-local.json",
+  // "AasxRepositoryFn": "C:\\HOMI\\Develop\\Aasx\\repo_Festo_demo_case_V3\\Festo-DemoCase-repo-V3-local.json",
   // "AasxToLoad": "C:\\MIHO\\Develop\\Aasx\\repo\\smt_pcn\\SMT_ProductChangeNotification_Draft_play_02.aasx",
   // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\repo\\dnp30\\IDTA 02006-3-0_Template_Digital Nameplate_AsciiDoc_Draft_v06.aasx",
   // "AasxToLoad": "C:\\HOMI\\Develop\\Aasx\\repo\\contactv11\\IDTA 02002-1-1_Template_ContactInformation_AsciiDoc_Draft_v04.aasx",
@@ -140,22 +140,6 @@
   "PluginPrefer": "ANYUI",
   "PluginDll": [
     {
-      "Path": "..\\..\\..\\..\\..\\..\\AasxPluginUaNetServer\\bin\\Debug\\net8.0-windows\\AasxPluginUaNetServer.dll",
-      "Args": [
-        "-single-nodeids",
-        "-single-keys",
-        "-ns",
-        "2",
-        "-ns",
-        "3"
-      ],
-      "Options": null
-    },
-    {
-      "Path": "..\\..\\..\\..\\..\\..\\AasxPluginUaNetClient\\bin\\Debug\\net8.0-windows\\AasxPluginUaNetClient.dll",
-      "Args": []
-    },
-    {
       "Path": "..\\..\\..\\..\\..\\..\\AasxPluginProductChangeNotifications\\bin\\Debug\\net8.0-windows\\AasxPluginProductChangeNotifications.dll",
       "Args": []
     },
@@ -214,8 +198,7 @@
     {
       "Path": "..\\..\\..\\..\\..\\..\\AasxPluginWebBrowser\\bin\\x64\\Debug\\AasxPluginWebBrowser.dll",
       "Args": []
-    },
-
+    } /*,
     // Festo specific from here on
     {
       "Path": "..\\..\\..\\..\\..\\..\\..\\..\\AasxFesto\\AasxFesto\\AasxPluginFluiddrawViewer\\bin\\Debug\\net8.0-windows\\AasxPluginFluiddrawViewer.dll",
@@ -224,7 +207,7 @@
     {
       "Path": "..\\..\\..\\..\\..\\..\\..\\..\\AasxFesto\\AasxFesto\\AasxPluginFluiddrawBom\\bin\\Debug\\net8.0-windows\\AasxPluginFluiddrawBom.dll",
       "Args": []
-    }
+    } */
   ],
   "SecureConnectPresets": [
     {
@@ -416,7 +399,7 @@
         "Tool(\"LocationPush\");",
         "Select(\"Submodel\", \"First\");",
         "Select(\"Submodel\", \"Next\");",
-        "Tool(\"ExportSmtAsciiDoc\", \"File\", \"C:\\Users\\homi0002\\Desktop\\tmp\\new.zip\");",
+        "Tool(\"ExportSmtAsciiDoc\", \"File\", \"C:\\Users\\Micha\\Desktop\\tmp\\new.zip\");",
         "Tool(\"LocationPop\");"
       ]
     },
@@ -426,7 +409,7 @@
         "Tool(\"LocationPush\");",
         "Select(\"Submodel\", \"First\");",
         "Select(\"Submodel\", \"Next\");",
-        "Tool(\"ExportSmtAsciiDoc\", \"File\", \"C:\\Users\\homi0002\\Desktop\\tmp\\new.zip\", \"ExportHtml\", \"true\", \"ExportPdf\", \"false\", \"AntoraStyle\", \"false\", \"ViewResult\", \"true\");",
+        "Tool(\"ExportSmtAsciiDoc\", \"File\", \"C:\\Users\\Micha\\Desktop\\tmp\\new.zip\", \"ExportHtml\", \"true\", \"ExportPdf\", \"false\", \"AntoraStyle\", \"false\", \"ViewResult\", \"true\");",
         "Tool(\"LocationPop\");"
       ]
     }

--- a/src/AasxPluginExportTable/Smt/AnyUiDialogueSmtExport.cs
+++ b/src/AasxPluginExportTable/Smt/AnyUiDialogueSmtExport.cs
@@ -80,7 +80,7 @@ namespace AasxPluginExportTable.Smt
                     var panel = new AnyUiStackPanel();
                     var helper = new AnyUiSmallWidgetToolkit();
 
-                    var g = helper.AddSmallGrid(6, 2, new[] { "220:", "*" },
+                    var g = helper.AddSmallGrid(7, 2, new[] { "220:", "*" },
                                 padding: new AnyUiThickness(0, 5, 0, 5));
                     panel.Add(g);
 
@@ -166,7 +166,7 @@ namespace AasxPluginExportTable.Smt
                                 colSpan: 2),
                             (b) => { record.AntoraStyle = b; });
 
-                    // Row 4 : Export PDF
+                    // Row 5 : Export PDF
                     helper.AddSmallLabelTo(g, 5, 0, content: "Export PDF:",
                         verticalAlignment: AnyUiVerticalAlignment.Center,
                         verticalContentAlignment: AnyUiVerticalAlignment.Center);
@@ -178,6 +178,19 @@ namespace AasxPluginExportTable.Smt
                                 verticalContentAlignment: AnyUiVerticalAlignment.Center),
                                 colSpan: 2),
                             (b) => { record.ExportPdf = b; });
+
+                    // Row 6 : View
+                    helper.AddSmallLabelTo(g, 6, 0, content: "View result:",
+                        verticalAlignment: AnyUiVerticalAlignment.Center,
+                        verticalContentAlignment: AnyUiVerticalAlignment.Center);
+                    AnyUiUIElement.SetBoolFromControl(
+                        helper.Set(
+                            helper.AddSmallCheckBoxTo(g, 6, 1,
+                                content: "(export command given by options will be executed)",
+                                isChecked: record.ViewResult,
+                                verticalContentAlignment: AnyUiVerticalAlignment.Center),
+                                colSpan: 2),
+                            (b) => { record.ViewResult = b; });
 
                     // give back
                     return panel;

--- a/src/Notes_V3.md
+++ b/src/Notes_V3.md
@@ -12,10 +12,10 @@ These projects need to be UNLOADED (for Visual Studio), to get a compiling solut
 * AasxSchemaExport.Tests
 * AasxRestConsoleServer
 * AasxToolkit.Tests
-* AasxUaNetConsoleServer
+* (AasxUaNetConsoleServer)
 * AasxPackageExplorer.GuiTests
 * AasxPackageExplorer.Tests
-* BlazorUI
+* (BlazorUI)
 
 ## Observations
 


### PR DESCRIPTION
** Ready to be merged with main branch. **

This quick fix enables the AasxPluginExportTable plugin to directly view AsciiDoc.
To enable this, the "Export HTML" and "View Results" options need to be ticked.

Additionally, the `AasxPluginExportTable.options.json` need to be configured as this:
```
"SmtExportHtmlCmd": "docker",
"SmtExportHtmlArgs": "run -it -v %WD%:/documents/ asciidoctor/docker-asciidoctor asciidoctor -r asciidoctor-diagram -a stylesheet=asciidoc-style-idta.css %ADOC%",
"SmtExportViewCmd": "cmd.exe",
"SmtExportViewArgs": "/c start %WD%\\%HTML% && ping 127.0.0.1 -n 5 >nul",
```

This comes in very handy, especially when called from a keyboard shortcut from `AasxPackageExplorer.options.json`:
```
"ScriptPresets": [
  [..]
  {
    "Name": "AsciiDoc - Just export (Ctrl+Shift+7)",
    "Lines": [
      "Tool(\"LocationPush\");",
      "Select(\"Submodel\", \"First\");",
      "Select(\"Submodel\", \"Next\");",
      "Tool(\"ExportSmtAsciiDoc\", \"File\", \"C:\\Users\\Micha\\Desktop\\tmp\\new.zip\");",
      "Tool(\"LocationPop\");"
    ]
  },
  {
    "Name": "AsciiDoc - Export and view  (Ctrl+Shift+8)",
    "Lines": [
      "Tool(\"LocationPush\");",
      "Select(\"Submodel\", \"First\");",
      "Select(\"Submodel\", \"Next\");",
      "Tool(\"ExportSmtAsciiDoc\", \"File\", \"C:\\Users\\Micha\\Desktop\\tmp\\new.zip\", \"ExportHtml\", \"true\", \"ExportPdf\", \"false\", \"AntoraStyle\", \"false\", \"ViewResult\", \"true\");",
      "Tool(\"LocationPop\");"
    ]
  }
]
```