### PR TITLE
Fix GitHub Issue

### DIFF
--- a/src/AasxPackageExplorer/AasxPackageExplorer.options-for-debug.json
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.options-for-debug.json
@@ -10,6 +10,8 @@
   "TemplateIdSubmodelTemplate": "https://example.com/ids/sm/DDDD_DDDD_DDDD_DDDD",
   "TemplateIdConceptDescription": "https://example.com/ids/cd/DDDD_DDDD_DDDD_DDDD",
   "EclassDir": ".\\eclass\\",
+  "DefaultLang": "en,de",
+  "OfferedLangs": "af-ZA,am-ET,ar-AE,ar-BH,ar-DZ,ar-EG,ar-IQ,ar-JO,ar-KW,ar-LB,ar-LY,ar-MA,ar-OM,ar-QA,ar-SA,ar-SD,ar-SY,ar-TN,ar-YE,as-IN,az-az,ba-RU,be-BY,bg-BG,bn-BD,bn-IN,bo-CN,br-FR,ca-ES,co-FR,cs-CZ,cy-GB,da-DK,de-DE,de-AT,de-CH,de-LI,de-LU,dv-MV,el-CY,el-GR,en-GB,en-AU,en-BZ,en-CA,en-cb,en-IE,en-IN,en-JM,en-MT,en-MY,en-NZ,en-PH,en-SG,en-TT,en-US,en-ZA,en-ZW,es-ES,es-AR,es-BO,es-CL,es-CO,es-CR,es-DO,es-EC,es-GT,es-HN,es-MX,es-NI,es-PA,es-PE,es-PR,es-PY,es-SV,es-US,es-UY,es-VE,et-EE,eu-ES,fa-IR,fi-FI,fo-FO,fr-FR,fr-BE,fr-CA,fr-CH,fr-LU,fr-MC,fy-NL,ga-IE,gd-GB,gd-ie,gl-ES,gu-IN,he-IL,hi-IN,hr-BA,hr-HR,hu-HU,hy-AM,id-ID,ig-NG,ii-CN,in-ID,is-IS,it-CH,it-IT,iw-IL,ja-JP,ka-GE,kk-KZ,kl-GL,km-KH,kn-IN,ko-KR,ky-KG,lb-LU,lo-LA,lt-LT,lv-LV,mi-NZ,mk-MK,ml-IN,mn-MN,mr-IN,ms-BN,ms-MY,mt-MT,nb-NO,ne-NP,nl-BE,nl-NL,nn-NO,no-no,oc-FR,or-IN,pa-IN,pl-PL,ps-AF,pt-BR,pt-PT,rm-CH,ro-mo,ro-RO,ru-mo,ru-RU,rw-RW,sa-IN,se-FI,se-NO,se-SE,si-LK,sk-SK,sl-SI,sq-AL,sr-BA,sr-CS,sr-ME,sr-RS,sr-sp,sv-FI,sv-SE,sw-KE,ta-IN,te-IN,th-TH,tk-TM,tn-ZA,tr-TR,tt-RU,ug-CN,uk-UA,ur-PK,uz-uz,vi-VN,wo-SN,xh-ZA,yo-NG,zh-CN,zh-HK,zh-MO,zh-SG,zh-TW,zu-ZA",
   "LogoFile": "Logo_IDTA_Custom.png",
   "QualifiersFile": "qualifier-presets.json",
   "ContentHome": "https://github.com/admin-shell/io/blob/master/README.md",

--- a/src/AasxPackageExplorer/AasxPackageExplorer.options-for-release.json
+++ b/src/AasxPackageExplorer/AasxPackageExplorer.options-for-release.json
@@ -10,6 +10,8 @@
   "TemplateIdSubmodelTemplate": "https://example.com/ids/sm/DDDD_DDDD_DDDD_DDDD",
   "TemplateIdConceptDescription": "https://example.com/ids/cd/DDDD_DDDD_DDDD_DDDD",
   "EclassDir": ".\\eclass\\",
+  "DefaultLang": "en,de",
+  "OfferedLangs": "af-ZA,am-ET,ar-AE,ar-BH,ar-DZ,ar-EG,ar-IQ,ar-JO,ar-KW,ar-LB,ar-LY,ar-MA,ar-OM,ar-QA,ar-SA,ar-SD,ar-SY,ar-TN,ar-YE,as-IN,az-az,ba-RU,be-BY,bg-BG,bn-BD,bn-IN,bo-CN,br-FR,ca-ES,co-FR,cs-CZ,cy-GB,da-DK,de-DE,de-AT,de-CH,de-LI,de-LU,dv-MV,el-CY,el-GR,en-GB,en-AU,en-BZ,en-CA,en-cb,en-IE,en-IN,en-JM,en-MT,en-MY,en-NZ,en-PH,en-SG,en-TT,en-US,en-ZA,en-ZW,es-ES,es-AR,es-BO,es-CL,es-CO,es-CR,es-DO,es-EC,es-GT,es-HN,es-MX,es-NI,es-PA,es-PE,es-PR,es-PY,es-SV,es-US,es-UY,es-VE,et-EE,eu-ES,fa-IR,fi-FI,fo-FO,fr-FR,fr-BE,fr-CA,fr-CH,fr-LU,fr-MC,fy-NL,ga-IE,gd-GB,gd-ie,gl-ES,gu-IN,he-IL,hi-IN,hr-BA,hr-HR,hu-HU,hy-AM,id-ID,ig-NG,ii-CN,in-ID,is-IS,it-CH,it-IT,iw-IL,ja-JP,ka-GE,kk-KZ,kl-GL,km-KH,kn-IN,ko-KR,ky-KG,lb-LU,lo-LA,lt-LT,lv-LV,mi-NZ,mk-MK,ml-IN,mn-MN,mr-IN,ms-BN,ms-MY,mt-MT,nb-NO,ne-NP,nl-BE,nl-NL,nn-NO,no-no,oc-FR,or-IN,pa-IN,pl-PL,ps-AF,pt-BR,pt-PT,rm-CH,ro-mo,ro-RO,ru-mo,ru-RU,rw-RW,sa-IN,se-FI,se-NO,se-SE,si-LK,sk-SK,sl-SI,sq-AL,sr-BA,sr-CS,sr-ME,sr-RS,sr-sp,sv-FI,sv-SE,sw-KE,ta-IN,te-IN,th-TH,tk-TM,tn-ZA,tr-TR,tt-RU,ug-CN,uk-UA,ur-PK,uz-uz,vi-VN,wo-SN,xh-ZA,yo-NG,zh-CN,zh-HK,zh-MO,zh-SG,zh-TW,zu-ZA",
   "LogoFile": "Logo_IDTA_Custom.png",
   "QualifiersFile": "qualifier-presets.json",
   "ContentHome": "https://github.com/admin-shell/io/blob/master/README.md",

--- a/src/AasxPackageLogic/MainWindowTools.cs
+++ b/src/AasxPackageLogic/MainWindowTools.cs
@@ -28,6 +28,7 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Aas = AasCore.Aas3_0;
@@ -999,35 +1000,59 @@ namespace AasxPackageExplorer
                 using (var file = System.IO.File.OpenRead(sourceFn))
                 {
                     var node = System.Text.Json.Nodes.JsonNode.Parse(file);
-                    readSm = Aas.Jsonization.Deserialize.SubmodelFrom(node);
+                    if (node is JsonObject nodeObject)
+                    {
+                        if (nodeObject.ContainsKey("submodels"))
+                        {
+                            var submodelsArray = nodeObject["submodels"] as JsonArray;
+                            foreach (var submodel in submodelsArray)
+                            {
+                                readSm = Aas.Jsonization.Deserialize.SubmodelFrom(submodel);
+                                ReadAndAddSubmodel(readSm, env, aas, ticket);
+                            }
+                        }
+                        else
+                        {
+                            readSm = Aas.Jsonization.Deserialize.SubmodelFrom(nodeObject);
+                            ReadAndAddSubmodel(readSm, env, aas, ticket);
+                        }
+                    }
+                    else 
+                    {
+                        throw new Exception("Unexpected JSON Serialization. Expecting a serialization for submodels (list) or a single submodel");
+                    }
                 }
 
-                // need id for idempotent behaviour
-                if (readSm == null || readSm.Id == null)
-                {
-                    LogErrorToTicket(ticket,
-                        "Import Submodel from JSON: Identification of SubModel is (null).");
-                    return;
-                }
-
-                // add Submodel
-                var existingSm = env.FindSubmodelById(readSm.Id);
-                if (existingSm != null)
-                    env.Remove(existingSm);
-                env.Add(readSm);
-
-                // add SubmodelRef to AAS
-                // access the AAS
-                var newsmr = ExtendReference.CreateFromKey(new Aas.Key(Aas.KeyTypes.Submodel, readSm.Id));
-                var existsmr = aas.HasSubmodelReference(newsmr);
-                if (!existsmr)
-                    aas.Add(newsmr);
             }
             catch (Exception ex)
             {
                 LogErrorToTicket(ticket, ex,
                     "Import Submodel from JSON: Can not read Submodel.");
             }
+        }
+
+        public void ReadAndAddSubmodel(ISubmodel readSm, IEnvironment env, IAssetAdministrationShell aas, AasxMenuActionTicket ticket)
+        {
+            // need id for idempotent behaviour
+            if (readSm == null || readSm.Id == null)
+            {
+                LogErrorToTicket(ticket,
+                    "Import Submodel from JSON: Identification of SubModel is (null).");
+                return;
+            }
+
+            // add Submodel
+            var existingSm = env.FindSubmodelById(readSm.Id);
+            if (existingSm != null)
+                env.Remove(existingSm);
+            env.Add(readSm);
+
+            // add SubmodelRef to AAS
+            // access the AAS
+            var newsmr = ExtendReference.CreateFromKey(new Aas.Key(Aas.KeyTypes.Submodel, readSm.Id));
+            var existsmr = aas.HasSubmodelReference(newsmr);
+            if (!existsmr)
+                aas.Add(newsmr);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes GH Issue #254.

With this fix, both the mulitple submodels as array,
 and a single submodel can be imported to the package explorer.

This way the functionality is also interoperable 
with the package explorer.
```
{
    "submodels": [
        {
            "modelType": "Submodel",
            "id": "https://acplt.org/Simple_Submodel"
        }
    ]
}
```

Single Submodel:
```
{
    "modelType": "Submodel",
    "id": "https://acplt.org/Simple_Submodel"
}
```